### PR TITLE
Fix test_requires prereqs

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Module::Build;
+use Module::Build 0.4004;
 
 Module::Build->new(
     module_name        => 'DBIx::Connector',

--- a/Build.PL
+++ b/Build.PL
@@ -6,10 +6,9 @@ Module::Build->new(
     module_name        => 'DBIx::Connector',
     license            => 'perl',
     configure_requires => {
-        'Module::Build' => '0.30',
+        'Module::Build' => '0.4004', # test_requires
     },
-    build_requires     => {
-        'Module::Build'    => '0.30',
+    test_requires     => {
         'Test::More'       => '0.88',
         'Test::MockModule' => '0.05',
     },


### PR DESCRIPTION
Test prerequisites should not be declared in the build phase wherever possible, so they don't need to be installed unless tests will be run. Module::Build supports test_requires from 0.4004. The configure_requires prerequisite is sufficient to install a new enough Module::Build where configure prereqs are honored; build_requires is too late to install a new enough one on older toolchains anyway.