### PR TITLE
prereqs only used in the test phase should be identified as test_requires, not build_requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,8 +8,7 @@ Module::Build->new(
     configure_requires => {
         'Module::Build' => '0.30',
     },
-    build_requires     => {
-        'Module::Build'    => '0.30',
+    test_requires     => {
         'Test::More'       => '0.88',
         'Test::MockModule' => '0.05',
     },


### PR DESCRIPTION

This prevents these prereqs from being introduced by systems that do not run tests by default, such as carton.